### PR TITLE
Fix TypeScript error: replace toast.warning with toast.error

### DIFF
--- a/frontend/src/pages/RestaurantDetailPage.tsx
+++ b/frontend/src/pages/RestaurantDetailPage.tsx
@@ -108,7 +108,7 @@ const RestaurantDetailPage = () => {
           if (!response.data.hasDifferences && !response.data.hasLostStars) {
             toast.success('Restaurant data is already up to date!');
           } else if (response.data.hasLostStars) {
-            toast.warning('Restaurant no longer has Michelin stars');
+            toast.error('Restaurant no longer has Michelin stars');
           }
         } else {
           toast.error('Could not find restaurant on Michelin Guide');


### PR DESCRIPTION
The react-hot-toast library does not have a warning() method. Changed to error() since it's alerting about a problem (restaurant losing Michelin stars).

Fixes #11

Generated with [Claude Code](https://claude.ai/code)