### PR TITLE
Fix profile loading issue in dashboard

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -74,7 +74,7 @@ const DashboardPage = () => {
     return <LoadingSpinner />;
   }
 
-  if (!profile?.data || !user) {
+  if (!profile?.data?.user || !user) {
     return (
       <div className="text-center py-12">
         <h1 className="text-2xl font-bold text-gray-900 mb-4">Unable to load profile</h1>


### PR DESCRIPTION
Fixes #14

## Summary
Fixed the "Unable to load profile" error on the Dashboard page by correcting the profile data validation check.

## Changes
- Updated `frontend/src/pages/DashboardPage.tsx` to check `!profile?.data?.user` instead of `!profile?.data`
- The backend API returns `{ user, stats }`, so we need to validate the `user` property exists

## Testing
The dashboard should now load correctly for authenticated users without showing the "Unable to load profile" error.

Generated with [Claude Code](https://claude.ai/code)