### PR TITLE
feat: allow multiple visits to the same restaurant

### DIFF
--- a/backend/prisma/migrations/20260105000000_allow_multiple_visits/migration.sql
+++ b/backend/prisma/migrations/20260105000000_allow_multiple_visits/migration.sql
@@ -1,0 +1,5 @@
+-- Drop the unique constraint on user_id and restaurant_id
+DROP INDEX IF EXISTS "user_visits_userId_restaurantId_key";
+
+-- Add composite index for query performance
+CREATE INDEX IF NOT EXISTS "user_visits_userId_restaurantId_idx" ON "user_visits"("user_id", "restaurant_id");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -63,9 +63,9 @@ model UserVisit {
   user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
   restaurant Restaurant @relation(fields: [restaurantId], references: [id], onDelete: Cascade)
 
-  @@unique([userId, restaurantId])
   @@index([userId])
   @@index([restaurantId])
+  @@index([userId, restaurantId])
   @@map("user_visits")
 }
 

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -35,7 +35,7 @@ router.get('/profile', authenticateToken, async (req: AuthRequest, res, next) =>
     const starStats = await prisma.$queryRaw`
       SELECT
         r.michelin_stars as stars,
-        COUNT(*)::int as count
+        COUNT(DISTINCT r.id)::int as count
       FROM user_visits uv
       JOIN restaurants r ON uv.restaurant_id = r.id
       WHERE uv.user_id = ${userId}
@@ -46,7 +46,7 @@ router.get('/profile', authenticateToken, async (req: AuthRequest, res, next) =>
     const countryStats = await prisma.$queryRaw`
       SELECT
         r.country,
-        COUNT(*)::int as count
+        COUNT(DISTINCT r.id)::int as count
       FROM user_visits uv
       JOIN restaurants r ON uv.restaurant_id = r.id
       WHERE uv.user_id = ${userId}
@@ -109,7 +109,7 @@ router.get('/profile/:username', async (req, res, next) => {
     const starStats = await prisma.$queryRaw`
       SELECT
         r.michelin_stars as stars,
-        COUNT(*)::int as count
+        COUNT(DISTINCT r.id)::int as count
       FROM user_visits uv
       JOIN restaurants r ON uv.restaurant_id = r.id
       WHERE uv.user_id = ${user.id}

--- a/backend/src/routes/visits.ts
+++ b/backend/src/routes/visits.ts
@@ -26,47 +26,53 @@ router.post('/', async (req: AuthRequest, res, next) => {
       return next(createError('Restaurant not found', 404));
     }
 
-    // Check if this is the first visit to this restaurant
-    const existingVisits = await prisma.userVisit.findMany({
-      where: {
-        userId,
-        restaurantId,
-      },
-    });
-
-    const isFirstVisit = existingVisits.length === 0;
-
-    const visit = await prisma.userVisit.create({
-      data: {
-        userId,
-        restaurantId,
-        dateVisited: new Date(dateVisited),
-        notes,
-      },
-      include: {
-        restaurant: true,
-      },
-    });
-
-    // Only award points on first visit
-    if (isFirstVisit) {
-      await prisma.user.update({
-        where: { id: userId },
-        data: {
-          totalScore: {
-            increment: restaurant.michelinStars,
-          },
-          restaurantsVisitedCount: {
-            increment: 1,
-          },
+    // Use a transaction to atomically check, create, and update scores
+    // This prevents race conditions where concurrent requests could both award first-visit points
+    const result = await prisma.$transaction(async (tx) => {
+      // Check if this is the first visit to this restaurant
+      const existingVisits = await tx.userVisit.findMany({
+        where: {
+          userId,
+          restaurantId,
         },
       });
-    }
+
+      const isFirstVisit = existingVisits.length === 0;
+
+      const visit = await tx.userVisit.create({
+        data: {
+          userId,
+          restaurantId,
+          dateVisited: new Date(dateVisited),
+          notes,
+        },
+        include: {
+          restaurant: true,
+        },
+      });
+
+      // Only award points on first visit
+      if (isFirstVisit) {
+        await tx.user.update({
+          where: { id: userId },
+          data: {
+            totalScore: {
+              increment: restaurant.michelinStars,
+            },
+            restaurantsVisitedCount: {
+              increment: 1,
+            },
+          },
+        });
+      }
+
+      return { visit, isFirstVisit };
+    });
 
     res.status(201).json({
       message: 'Visit recorded successfully',
-      visit,
-      pointsEarned: isFirstVisit ? restaurant.michelinStars : 0,
+      visit: result.visit,
+      pointsEarned: result.isFirstVisit ? restaurant.michelinStars : 0,
     });
   } catch (error) {
     next(error);
@@ -131,35 +137,39 @@ router.delete('/:id', async (req: AuthRequest, res, next) => {
       return next(createError('Not authorized to delete this visit', 403));
     }
 
-    // Check if there are other visits to this restaurant
-    const otherVisits = await prisma.userVisit.findMany({
-      where: {
-        userId,
-        restaurantId: visit.restaurantId,
-        id: { not: id },
-      },
-    });
-
-    const isLastVisit = otherVisits.length === 0;
-
-    await prisma.userVisit.delete({
-      where: { id },
-    });
-
-    // Only deduct points if this was the last visit to this restaurant
-    if (isLastVisit) {
-      await prisma.user.update({
-        where: { id: userId },
-        data: {
-          totalScore: {
-            decrement: visit.restaurant.michelinStars,
-          },
-          restaurantsVisitedCount: {
-            decrement: 1,
-          },
+    // Use a transaction to atomically check, delete, and update scores
+    // This prevents race conditions where concurrent deletes could miscompute the last-visit status
+    await prisma.$transaction(async (tx) => {
+      // Check if there are other visits to this restaurant
+      const otherVisits = await tx.userVisit.findMany({
+        where: {
+          userId,
+          restaurantId: visit.restaurantId,
+          id: { not: id },
         },
       });
-    }
+
+      const isLastVisit = otherVisits.length === 0;
+
+      await tx.userVisit.delete({
+        where: { id },
+      });
+
+      // Only deduct points if this was the last visit to this restaurant
+      if (isLastVisit) {
+        await tx.user.update({
+          where: { id: userId },
+          data: {
+            totalScore: {
+              decrement: visit.restaurant.michelinStars,
+            },
+            restaurantsVisitedCount: {
+              decrement: 1,
+            },
+          },
+        });
+      }
+    });
 
     res.json({ message: 'Visit deleted successfully' });
   } catch (error) {

--- a/scraper-service/prisma/schema.prisma
+++ b/scraper-service/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   username                String      @unique
   email                   String      @unique
   passwordHash            String      @map("password_hash")
+  admin                   Boolean     @default(false)
   totalScore              Int         @default(0) @map("total_score")
   restaurantsVisitedCount Int         @default(0) @map("restaurants_visited_count")
   createdAt               DateTime    @default(now()) @map("created_at")
@@ -61,9 +62,9 @@ model UserVisit {
   user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
   restaurant Restaurant @relation(fields: [restaurantId], references: [id], onDelete: Cascade)
 
-  @@unique([userId, restaurantId])
   @@index([userId])
   @@index([restaurantId])
+  @@index([userId, restaurantId])
   @@map("user_visits")
 }
 


### PR DESCRIPTION
Closes #19

This PR adds the ability to track multiple visits to the same restaurant, while only awarding points on the first visit.

## Changes
- Removed unique constraint on UserVisit model (userId, restaurantId)
- Award points only on first visit to a restaurant
- Deduct points only when deleting last visit to a restaurant
- Updated stats queries to count unique restaurants
- Added database migration for schema changes

## Testing
After deploying, you'll need to run the migration:
```bash
cd backend
npx prisma migrate deploy
```

Generated with [Claude Code](https://claude.ai/code)