### PR TITLE
Add enhanced visit tracking fields

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -58,6 +58,9 @@ model UserVisit {
   restaurantId String    @map("restaurant_id")
   dateVisited  DateTime  @map("date_visited")
   notes        String?
+  bestDish     String?   @map("best_dish")
+  occasion     String?
+  moodRating   Int?      @map("mood_rating")
   createdAt    DateTime  @default(now()) @map("created_at")
 
   user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/backend/src/routes/visits.ts
+++ b/backend/src/routes/visits.ts
@@ -15,7 +15,7 @@ router.post('/', async (req: AuthRequest, res, next) => {
       return next(createError(error.details[0].message, 400));
     }
 
-    const { restaurantId, dateVisited, notes } = value;
+    const { restaurantId, dateVisited, notes, bestDish, occasion, moodRating } = value;
     const userId = req.userId!;
 
     // Use a transaction to atomically check, create, and update scores
@@ -51,6 +51,9 @@ router.post('/', async (req: AuthRequest, res, next) => {
           restaurantId,
           dateVisited: new Date(dateVisited),
           notes,
+          bestDish,
+          occasion,
+          moodRating,
         },
         include: {
           restaurant: true,

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -15,6 +15,9 @@ export const visitSchema = Joi.object({
   restaurantId: Joi.string().required(),
   dateVisited: Joi.date().iso().required(),
   notes: Joi.string().allow('').optional(),
+  bestDish: Joi.string().allow('').optional(),
+  occasion: Joi.string().valid('celebration', 'solo', 'work', 'spontaneous').allow('').optional(),
+  moodRating: Joi.number().integer().min(1).max(5).optional(),
 });
 
 export const restaurantQuerySchema = Joi.object({

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -266,8 +266,38 @@ const DashboardPage = () => {
                         </div>
                       </div>
 
-                      {visit.notes && (
+                      {visit.occasion && (
+                        <div className="mt-2">
+                          <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-full">
+                            {visit.occasion}
+                          </span>
+                        </div>
+                      )}
+
+                      {visit.bestDish && (
                         <p className="text-gray-700 mt-2 text-sm bg-gray-50 p-2 rounded">
+                          <span className="font-medium">Best dish:</span> {visit.bestDish}
+                        </p>
+                      )}
+
+                      {visit.moodRating && (
+                        <div className="flex items-center mt-2">
+                          <span className="text-sm text-gray-600 mr-2">Experience:</span>
+                          <div className="flex">
+                            {[...Array(5)].map((_, i) => (
+                              <Star
+                                key={i}
+                                className={`h-3 w-3 ${
+                                  i < visit.moodRating ? 'text-yellow-400 fill-current' : 'text-gray-300'
+                                }`}
+                              />
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {visit.notes && (
+                        <p className="text-gray-700 mt-2 text-sm bg-gray-50 p-2 rounded italic">
                           {visit.notes}
                         </p>
                       )}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -139,14 +139,38 @@ const ProfilePage = () => {
                           {visit.restaurant.city}, {visit.restaurant.country}
                         </span>
                       </div>
-                      <div className="flex items-center mt-1 text-xs text-gray-500">
-                        <Calendar className="h-3 w-3 mr-1" />
-                        {new Date(visit.dateVisited).toLocaleDateString()}
+                      <div className="flex items-center flex-wrap gap-2 mt-1 text-xs text-gray-500">
+                        <div className="flex items-center">
+                          <Calendar className="h-3 w-3 mr-1" />
+                          {new Date(visit.dateVisited).toLocaleDateString()}
+                        </div>
+                        {visit.occasion && (
+                          <span className="bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full">
+                            {visit.occasion}
+                          </span>
+                        )}
                       </div>
                     </div>
+                    {visit.moodRating && (
+                      <div className="flex ml-2">
+                        {[...Array(5)].map((_, i) => (
+                          <Star
+                            key={i}
+                            className={`h-3 w-3 ${
+                              i < visit.moodRating ? 'text-yellow-400 fill-current' : 'text-gray-300'
+                            }`}
+                          />
+                        ))}
+                      </div>
+                    )}
                   </div>
+                  {visit.bestDish && (
+                    <p className="text-sm text-gray-700 mt-2 bg-gray-50 p-2 rounded">
+                      <span className="font-medium">Best dish:</span> {visit.bestDish}
+                    </p>
+                  )}
                   {visit.notes && (
-                    <p className="text-sm text-gray-600 mt-2 bg-gray-50 p-2 rounded">
+                    <p className="text-sm text-gray-600 mt-2 bg-gray-50 p-2 rounded italic">
                       {visit.notes}
                     </p>
                   )}

--- a/frontend/src/pages/RestaurantDetailPage.tsx
+++ b/frontend/src/pages/RestaurantDetailPage.tsx
@@ -12,6 +12,9 @@ import { getStarCount } from '../utils/restaurant';
 interface VisitForm {
   dateVisited: string;
   notes: string;
+  bestDish: string;
+  occasion: string;
+  moodRating: number;
 }
 
 interface EditForm {
@@ -44,6 +47,9 @@ const RestaurantDetailPage = () => {
     defaultValues: {
       dateVisited: new Date().toISOString().split('T')[0],
       notes: '',
+      bestDish: '',
+      occasion: '',
+      moodRating: 3,
     },
   });
 
@@ -141,6 +147,9 @@ const RestaurantDetailPage = () => {
       restaurantId: id!,
       dateVisited: data.dateVisited,
       notes: data.notes,
+      bestDish: data.bestDish,
+      occasion: data.occasion,
+      moodRating: data.moodRating ? Number(data.moodRating) : undefined,
     });
   };
 
@@ -464,13 +473,66 @@ const RestaurantDetailPage = () => {
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
+                Best Dish (optional)
+              </label>
+              <input
+                {...register('bestDish')}
+                type="text"
+                className="input-field"
+                placeholder="What was the standout dish?"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Occasion (optional)
+              </label>
+              <select
+                {...register('occasion')}
+                className="input-field"
+              >
+                <option value="">Select occasion...</option>
+                <option value="celebration">Celebration</option>
+                <option value="solo">Solo</option>
+                <option value="work">Work</option>
+                <option value="spontaneous">Spontaneous</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Experience Rating (optional)
+              </label>
+              <div className="flex items-center space-x-2">
+                <span className="text-sm text-gray-600">Memorable</span>
+                <input
+                  {...register('moodRating', { valueAsNumber: true })}
+                  type="range"
+                  min="1"
+                  max="5"
+                  step="1"
+                  className="flex-1"
+                />
+                <span className="text-sm text-gray-600">Life-changing</span>
+              </div>
+              <div className="flex justify-between text-xs text-gray-500 mt-1 px-1">
+                <span>1</span>
+                <span>2</span>
+                <span>3</span>
+                <span>4</span>
+                <span>5</span>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
                 Notes (optional)
               </label>
               <textarea
                 {...register('notes')}
                 rows={3}
                 className="input-field"
-                placeholder="Share your experience, favorite dishes, etc."
+                placeholder="Share your overall experience..."
               />
             </div>
 
@@ -503,14 +565,39 @@ const RestaurantDetailPage = () => {
               <div key={visit.id} className="flex items-start space-x-3 p-3 bg-gray-50 rounded-lg">
                 <User className="h-5 w-5 text-gray-400 mt-0.5" />
                 <div className="flex-1">
-                  <div className="flex items-center space-x-2">
+                  <div className="flex items-center space-x-2 mb-1">
                     <span className="font-medium">{visit.user.username}</span>
                     <span className="text-sm text-gray-500">
                       visited on {new Date(visit.dateVisited).toLocaleDateString()}
                     </span>
+                    {visit.occasion && (
+                      <span className="text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full">
+                        {visit.occasion}
+                      </span>
+                    )}
                   </div>
+                  {visit.bestDish && (
+                    <p className="text-sm text-gray-700 mt-1">
+                      <span className="font-medium">Best dish:</span> {visit.bestDish}
+                    </p>
+                  )}
+                  {visit.moodRating && (
+                    <div className="flex items-center mt-1">
+                      <span className="text-sm text-gray-600 mr-2">Experience:</span>
+                      <div className="flex">
+                        {[...Array(5)].map((_, i) => (
+                          <Star
+                            key={i}
+                            className={`h-3 w-3 ${
+                              i < visit.moodRating ? 'text-yellow-400 fill-current' : 'text-gray-300'
+                            }`}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  )}
                   {visit.notes && (
-                    <p className="text-sm text-gray-600 mt-1">{visit.notes}</p>
+                    <p className="text-sm text-gray-600 mt-2 italic">{visit.notes}</p>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Adds three new optional fields to visit tracking to capture richer data about each dining experience:

- **Best Dish** (free text): Record the standout dish from the visit
- **Occasion** (celebration/solo/work/spontaneous): Categorize the type of visit
- **Experience Rating** (1-5 slider): Rate the experience from memorable to life-changing

All fields are optional and backward compatible with existing visits.

## Changes

- Updated UserVisit database model with 3 new optional fields
- Enhanced visit form with new input controls
- Updated all visit display components to show new data
- Added backend validation for new fields

## Database Migration Required

Before deploying, run:
```bash
cd backend
npx prisma migrate dev --name add_visit_enhancements
```

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)