### PR TITLE
feat: implement wishlist feature with intent signals

### DIFF
--- a/backend/prisma/migrations/20260112000000_add_wishlist_feature/migration.sql
+++ b/backend/prisma/migrations/20260112000000_add_wishlist_feature/migration.sql
@@ -1,0 +1,28 @@
+-- AlterTable
+ALTER TABLE "restaurants" ADD COLUMN "booking_window_days" INTEGER;
+
+-- CreateTable
+CREATE TABLE "wishlists" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "restaurant_id" TEXT NOT NULL,
+    "note" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "wishlists_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "wishlists_user_id_idx" ON "wishlists"("user_id");
+
+-- CreateIndex
+CREATE INDEX "wishlists_restaurant_id_idx" ON "wishlists"("restaurant_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "wishlists_user_id_restaurant_id_key" ON "wishlists"("user_id", "restaurant_id");
+
+-- AddForeignKey
+ALTER TABLE "wishlists" ADD CONSTRAINT "wishlists_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "wishlists" ADD CONSTRAINT "wishlists_restaurant_id_fkey" FOREIGN KEY ("restaurant_id") REFERENCES "restaurants"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,32 +19,35 @@ model User {
   createdAt               DateTime    @default(now()) @map("created_at")
   updatedAt               DateTime    @updatedAt @map("updated_at")
 
-  visits UserVisit[]
+  visits    UserVisit[]
+  wishlists Wishlist[]
 
   @@map("users")
 }
 
 model Restaurant {
-  id           String   @id @default(cuid())
-  name         String
-  city         String
-  country      String
-  cuisineType  String   @map("cuisine_type")
-  michelinStars Int     @map("michelin_stars")
-  distinction  String?
-  yearAwarded  Int      @map("year_awarded")
-  address      String
-  latitude     Float?
-  longitude    Float?
-  description  String?
-  imageUrl     String?  @map("image_url")
-  phone        String?
-  website      String?
-  michelinUrl  String?  @map("michelin_url")
-  createdAt    DateTime @default(now()) @map("created_at")
-  updatedAt    DateTime @updatedAt @map("updated_at")
+  id                String   @id @default(cuid())
+  name              String
+  city              String
+  country           String
+  cuisineType       String   @map("cuisine_type")
+  michelinStars     Int      @map("michelin_stars")
+  distinction       String?
+  yearAwarded       Int      @map("year_awarded")
+  address           String
+  latitude          Float?
+  longitude         Float?
+  description       String?
+  imageUrl          String?  @map("image_url")
+  phone             String?
+  website           String?
+  michelinUrl       String?  @map("michelin_url")
+  bookingWindowDays Int?     @map("booking_window_days")
+  createdAt         DateTime @default(now()) @map("created_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
 
-  visits UserVisit[]
+  visits    UserVisit[]
+  wishlists Wishlist[]
 
   @@index([country, city])
   @@index([michelinStars])
@@ -96,4 +99,20 @@ model RawData {
   @@index([processed])
   @@index([scrapeDate])
   @@map("raw_data")
+}
+
+model Wishlist {
+  id           String   @id @default(cuid())
+  userId       String   @map("user_id")
+  restaurantId String   @map("restaurant_id")
+  note         String?
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  restaurant Restaurant @relation(fields: [restaurantId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, restaurantId])
+  @@index([userId])
+  @@index([restaurantId])
+  @@map("wishlists")
 }

--- a/backend/src/routes/restaurants.ts
+++ b/backend/src/routes/restaurants.ts
@@ -129,7 +129,26 @@ router.get('/:id', async (req, res, next) => {
       return next(createError('Restaurant not found', 404));
     }
 
-    res.json(restaurant);
+    // Get count of unique users who have visited (social indicator)
+    // Note: For beta, we're just showing the count, not the names
+    const uniqueVisitorsCount = await prisma.userVisit.groupBy({
+      by: ['userId'],
+      where: {
+        restaurantId: id,
+      },
+      _count: {
+        userId: true,
+      },
+    });
+
+    const socialIndicator = {
+      friendsVisitedCount: uniqueVisitorsCount.length,
+    };
+
+    res.json({
+      ...restaurant,
+      socialIndicator,
+    });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/wishlist.ts
+++ b/backend/src/routes/wishlist.ts
@@ -1,0 +1,212 @@
+import express from 'express';
+import { prisma } from '../utils/prisma';
+import { wishlistSchema } from '../utils/validation';
+import { authenticateToken, AuthRequest } from '../middleware/auth';
+import { createError } from '../middleware/errorHandler';
+
+const router = express.Router();
+
+router.use(authenticateToken);
+
+// Get user's wishlist
+router.get('/', async (req: AuthRequest, res, next) => {
+  try {
+    const userId = req.userId!;
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = parseInt(req.query.limit as string) || 20;
+    const skip = (page - 1) * limit;
+
+    const [wishlists, total] = await Promise.all([
+      prisma.wishlist.findMany({
+        where: { userId },
+        include: {
+          restaurant: true,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+        skip,
+        take: limit,
+      }),
+      prisma.wishlist.count({
+        where: { userId },
+      }),
+    ]);
+
+    const totalPages = Math.ceil(total / limit);
+
+    res.json({
+      wishlists,
+      pagination: {
+        current: page,
+        total: totalPages,
+        count: wishlists.length,
+        totalCount: total,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Add restaurant to wishlist
+router.post('/', async (req: AuthRequest, res, next) => {
+  try {
+    const { error, value } = wishlistSchema.validate(req.body);
+    if (error) {
+      return next(createError(error.details[0].message, 400));
+    }
+
+    const { restaurantId, note } = value;
+    const userId = req.userId!;
+
+    // Check if restaurant exists
+    const restaurant = await prisma.restaurant.findUnique({
+      where: { id: restaurantId },
+    });
+
+    if (!restaurant) {
+      return next(createError('Restaurant not found', 404));
+    }
+
+    // Check if already in wishlist
+    const existingWishlist = await prisma.wishlist.findUnique({
+      where: {
+        userId_restaurantId: {
+          userId,
+          restaurantId,
+        },
+      },
+    });
+
+    if (existingWishlist) {
+      return next(createError('Restaurant is already in your wishlist', 400));
+    }
+
+    // Create wishlist entry
+    const wishlist = await prisma.wishlist.create({
+      data: {
+        userId,
+        restaurantId,
+        note,
+      },
+      include: {
+        restaurant: true,
+      },
+    });
+
+    res.status(201).json({
+      message: 'Restaurant added to wishlist',
+      wishlist,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Update wishlist note
+router.patch('/:restaurantId', async (req: AuthRequest, res, next) => {
+  try {
+    const { restaurantId } = req.params;
+    const { note } = req.body;
+    const userId = req.userId!;
+
+    const wishlist = await prisma.wishlist.findUnique({
+      where: {
+        userId_restaurantId: {
+          userId,
+          restaurantId,
+        },
+      },
+    });
+
+    if (!wishlist) {
+      return next(createError('Wishlist entry not found', 404));
+    }
+
+    const updatedWishlist = await prisma.wishlist.update({
+      where: {
+        userId_restaurantId: {
+          userId,
+          restaurantId,
+        },
+      },
+      data: {
+        note,
+      },
+      include: {
+        restaurant: true,
+      },
+    });
+
+    res.json({
+      message: 'Wishlist note updated',
+      wishlist: updatedWishlist,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Remove restaurant from wishlist
+router.delete('/:restaurantId', async (req: AuthRequest, res, next) => {
+  try {
+    const { restaurantId } = req.params;
+    const userId = req.userId!;
+
+    const wishlist = await prisma.wishlist.findUnique({
+      where: {
+        userId_restaurantId: {
+          userId,
+          restaurantId,
+        },
+      },
+    });
+
+    if (!wishlist) {
+      return next(createError('Wishlist entry not found', 404));
+    }
+
+    await prisma.wishlist.delete({
+      where: {
+        userId_restaurantId: {
+          userId,
+          restaurantId,
+        },
+      },
+    });
+
+    res.json({ message: 'Restaurant removed from wishlist' });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Check if restaurant is in user's wishlist
+router.get('/check/:restaurantId', async (req: AuthRequest, res, next) => {
+  try {
+    const { restaurantId } = req.params;
+    const userId = req.userId!;
+
+    const wishlist = await prisma.wishlist.findUnique({
+      where: {
+        userId_restaurantId: {
+          userId,
+          restaurantId,
+        },
+      },
+      include: {
+        restaurant: true,
+      },
+    });
+
+    res.json({
+      inWishlist: !!wishlist,
+      wishlist: wishlist || null,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -14,6 +14,7 @@ import leaderboardRoutes from './routes/leaderboard';
 import scraperRoutes from './routes/scraper';
 import feedbackRoutes from './routes/feedback';
 import adminRoutes from './routes/admin';
+import wishlistRoutes from './routes/wishlist';
 import { errorHandler } from './middleware/errorHandler';
 
 dotenv.config();
@@ -107,6 +108,7 @@ app.use('/api/leaderboard', leaderboardRoutes);
 app.use('/api/scraper', scraperRoutes);
 app.use('/api/feedback', feedbackRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/wishlist', wishlistRoutes);
 
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'OK', timestamp: new Date().toISOString() });

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -29,3 +29,8 @@ export const restaurantQuerySchema = Joi.object({
   cuisineType: Joi.string().allow('').optional(),
   michelinStars: Joi.number().integer().min(0).max(3).optional(),
 });
+
+export const wishlistSchema = Joi.object({
+  restaurantId: Joi.string().required(),
+  note: Joi.string().allow('').optional(),
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import RestaurantDetailPage from './pages/RestaurantDetailPage';
 import DashboardPage from './pages/DashboardPage';
 import LeaderboardPage from './pages/LeaderboardPage';
 import ProfilePage from './pages/ProfilePage';
+import WishlistPage from './pages/WishlistPage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import LoadingSpinner from './components/LoadingSpinner';
@@ -33,6 +34,7 @@ function App() {
         {user && (
           <>
             <Route path="dashboard" element={<DashboardPage />} />
+            <Route path="wishlist" element={<WishlistPage />} />
           </>
         )}
       </Route>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from 'react-router-dom';
-import { Star, User, Trophy, Map, Home, LogOut } from 'lucide-react';
+import { Star, User, Trophy, Map, Home, LogOut, Bookmark } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 
 const Navbar = () => {
@@ -62,6 +62,13 @@ const Navbar = () => {
                       className="block px-4 py-2 text-gray-700 hover:bg-gray-50"
                     >
                       Profile
+                    </Link>
+                    <Link
+                      to="/wishlist"
+                      className="flex items-center space-x-2 px-4 py-2 text-gray-700 hover:bg-gray-50"
+                    >
+                      <Bookmark className="h-4 w-4" />
+                      <span>Wishlist</span>
                     </Link>
                     <button
                       onClick={handleLogout}

--- a/frontend/src/components/WishlistButton.tsx
+++ b/frontend/src/components/WishlistButton.tsx
@@ -1,0 +1,166 @@
+import { useState, useEffect } from 'react';
+import { wishlistAPI } from '../services/api';
+import { useAuth } from '../contexts/AuthContext';
+
+interface WishlistButtonProps {
+  restaurantId: string;
+  restaurantName: string;
+  onWishlistChange?: () => void;
+}
+
+export default function WishlistButton({
+  restaurantId,
+  restaurantName,
+  onWishlistChange
+}: WishlistButtonProps) {
+  const { user } = useAuth();
+  const [inWishlist, setInWishlist] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [showNoteInput, setShowNoteInput] = useState(false);
+  const [note, setNote] = useState('');
+
+  useEffect(() => {
+    if (user) {
+      checkWishlistStatus();
+    }
+  }, [restaurantId, user]);
+
+  const checkWishlistStatus = async () => {
+    try {
+      const response = await wishlistAPI.checkWishlist(restaurantId);
+      setInWishlist(response.data.inWishlist);
+      if (response.data.wishlist?.note) {
+        setNote(response.data.wishlist.note);
+      }
+    } catch (error) {
+      console.error('Error checking wishlist status:', error);
+    }
+  };
+
+  const handleToggleWishlist = async () => {
+    if (!user) return;
+
+    setLoading(true);
+    try {
+      if (inWishlist) {
+        await wishlistAPI.removeFromWishlist(restaurantId);
+        setInWishlist(false);
+        setNote('');
+        setShowNoteInput(false);
+      } else {
+        await wishlistAPI.addToWishlist({ restaurantId, note: note || undefined });
+        setInWishlist(true);
+        setShowNoteInput(false);
+      }
+      onWishlistChange?.();
+    } catch (error: any) {
+      console.error('Error toggling wishlist:', error);
+      alert(error.response?.data?.error || 'Failed to update wishlist');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUpdateNote = async () => {
+    if (!user || !inWishlist) return;
+
+    setLoading(true);
+    try {
+      await wishlistAPI.updateWishlistNote(restaurantId, note);
+      setShowNoteInput(false);
+    } catch (error: any) {
+      console.error('Error updating note:', error);
+      alert(error.response?.data?.error || 'Failed to update note');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!user) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2">
+        <button
+          onClick={handleToggleWishlist}
+          disabled={loading}
+          className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-colors ${
+            inWishlist
+              ? 'bg-amber-100 text-amber-700 hover:bg-amber-200 border border-amber-300'
+              : 'bg-white text-gray-700 hover:bg-gray-50 border border-gray-300'
+          } ${loading ? 'opacity-50 cursor-not-allowed' : ''}`}
+        >
+          <svg
+            className="w-5 h-5"
+            fill={inWishlist ? 'currentColor' : 'none'}
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+            />
+          </svg>
+          {inWishlist ? 'In Wishlist' : 'Add to Wishlist'}
+        </button>
+
+        {inWishlist && (
+          <button
+            onClick={() => setShowNoteInput(!showNoteInput)}
+            className="px-3 py-2 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors"
+            title="Add/edit note"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {showNoteInput && inWishlist && (
+        <div className="flex flex-col gap-2 p-3 bg-gray-50 rounded-lg border border-gray-200">
+          <label className="text-sm font-medium text-gray-700">
+            Why do you want to visit {restaurantName}?
+          </label>
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="E.g., For Tokyo trip, Special occasion, Birthday celebration..."
+            className="px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            rows={3}
+          />
+          <div className="flex gap-2">
+            <button
+              onClick={handleUpdateNote}
+              disabled={loading}
+              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
+            >
+              Save Note
+            </button>
+            <button
+              onClick={() => setShowNoteInput(false)}
+              className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 text-sm font-medium"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {note && !showNoteInput && inWishlist && (
+        <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg">
+          <p className="text-sm text-amber-800">
+            <span className="font-medium">Note:</span> {note}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/RestaurantDetailPage.tsx
+++ b/frontend/src/pages/RestaurantDetailPage.tsx
@@ -7,6 +7,7 @@ import { Star, MapPin, User, Plus, Trash2, Edit3, Save, X, RefreshCw } from 'luc
 import { restaurantAPI, visitAPI, scraperAPI } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import LoadingSpinner from '../components/LoadingSpinner';
+import WishlistButton from '../components/WishlistButton';
 import { getStarCount } from '../utils/restaurant';
 
 interface VisitForm {
@@ -423,6 +424,37 @@ const RestaurantDetailPage = () => {
               />
             </div>
           </form>
+        )}
+
+        {/* Wishlist and Social Indicators */}
+        {user && !isEditing && (
+          <div className="mt-6 pt-6 border-t space-y-4">
+            <div>
+              <h3 className="font-semibold text-gray-900 mb-3">Wishlist</h3>
+              <WishlistButton
+                restaurantId={id!}
+                restaurantName={restaurantData.name}
+                onWishlistChange={() => queryClient.invalidateQueries(['restaurant', id])}
+              />
+            </div>
+
+            {/* Social Indicator */}
+            {restaurantData.socialIndicator && restaurantData.socialIndicator.friendsVisitedCount > 0 && (
+              <div className="flex items-center gap-2 text-sm text-gray-600">
+                <User className="h-4 w-4" />
+                <span>{restaurantData.socialIndicator.friendsVisitedCount} {restaurantData.socialIndicator.friendsVisitedCount === 1 ? 'person has' : 'people have'} visited</span>
+              </div>
+            )}
+
+            {/* Booking Window Hint */}
+            {restaurantData.bookingWindowDays && (
+              <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                <p className="text-sm text-blue-800">
+                  <span className="font-medium">Booking tip:</span> Bookings typically open {restaurantData.bookingWindowDays} days in advance
+                </p>
+              </div>
+            )}
+          </div>
         )}
 
         {/* Visit Action */}

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -1,0 +1,221 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { Link } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import { Star, MapPin, Trash2, Edit3 } from 'lucide-react';
+import { wishlistAPI } from '../services/api';
+import { useAuth } from '../contexts/AuthContext';
+import LoadingSpinner from '../components/LoadingSpinner';
+import { Wishlist } from '../types';
+
+const WishlistPage = () => {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const [editingNote, setEditingNote] = useState<string | null>(null);
+  const [noteText, setNoteText] = useState('');
+
+  const { data: wishlistData, isLoading } = useQuery(
+    'user-wishlist',
+    () => wishlistAPI.getWishlist(1, 100),
+    { enabled: !!user }
+  );
+
+  const removeFromWishlistMutation = useMutation(
+    (restaurantId: string) => wishlistAPI.removeFromWishlist(restaurantId),
+    {
+      onSuccess: () => {
+        toast.success('Removed from wishlist');
+        queryClient.invalidateQueries('user-wishlist');
+      },
+      onError: (error: any) => {
+        toast.error(error.response?.data?.error || 'Failed to remove from wishlist');
+      },
+    }
+  );
+
+  const updateNoteMutation = useMutation(
+    ({ restaurantId, note }: { restaurantId: string; note: string }) =>
+      wishlistAPI.updateWishlistNote(restaurantId, note),
+    {
+      onSuccess: () => {
+        toast.success('Note updated');
+        queryClient.invalidateQueries('user-wishlist');
+        setEditingNote(null);
+        setNoteText('');
+      },
+      onError: (error: any) => {
+        toast.error(error.response?.data?.error || 'Failed to update note');
+      },
+    }
+  );
+
+  const handleStartEditNote = (wishlist: Wishlist) => {
+    setEditingNote(wishlist.restaurantId);
+    setNoteText(wishlist.note || '');
+  };
+
+  const handleSaveNote = (restaurantId: string) => {
+    updateNoteMutation.mutate({ restaurantId, note: noteText });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingNote(null);
+    setNoteText('');
+  };
+
+  if (!user) {
+    return (
+      <div className="text-center py-12">
+        <h1 className="text-2xl font-bold text-gray-900 mb-4">Please log in to view your wishlist</h1>
+        <Link to="/login" className="btn-primary">
+          Log In
+        </Link>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  const wishlists = wishlistData?.data?.wishlists || [];
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">My Wishlist</h1>
+        <p className="text-gray-600">
+          Restaurants you want to visit ({wishlists.length} {wishlists.length === 1 ? 'restaurant' : 'restaurants'})
+        </p>
+      </div>
+
+      {wishlists.length === 0 ? (
+        <div className="card text-center py-12">
+          <div className="mb-4">
+            <svg
+              className="mx-auto h-12 w-12 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+              />
+            </svg>
+          </div>
+          <h2 className="text-xl font-bold text-gray-900 mb-2">Your wishlist is empty</h2>
+          <p className="text-gray-600 mb-6">
+            Start adding restaurants you want to visit to your wishlist
+          </p>
+          <Link to="/restaurants" className="btn-primary">
+            Browse Restaurants
+          </Link>
+        </div>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {wishlists.map((wishlist) => (
+            <div key={wishlist.id} className="card hover:shadow-lg transition-shadow">
+              <Link to={`/restaurants/${wishlist.restaurant.id}`}>
+                <div className="mb-4">
+                  <h3 className="text-lg font-bold text-gray-900 mb-2 hover:text-blue-600 transition-colors">
+                    {wishlist.restaurant.name}
+                  </h3>
+                  <div className="flex items-center space-x-2 text-sm text-gray-600 mb-2">
+                    <MapPin className="h-4 w-4" />
+                    <span>{wishlist.restaurant.city}, {wishlist.restaurant.country}</span>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <div className="flex text-yellow-400">
+                      {[...Array(wishlist.restaurant.michelinStars)].map((_, i) => (
+                        <Star key={i} className="h-4 w-4 fill-current" />
+                      ))}
+                    </div>
+                    <span className="text-sm font-medium text-gray-700">
+                      {wishlist.restaurant.michelinStars} Star{wishlist.restaurant.michelinStars !== 1 ? 's' : ''}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {wishlist.restaurant.cuisineType}
+                    </span>
+                  </div>
+                </div>
+              </Link>
+
+              {/* Note Section */}
+              {editingNote === wishlist.restaurantId ? (
+                <div className="space-y-2 mb-4">
+                  <textarea
+                    value={noteText}
+                    onChange={(e) => setNoteText(e.target.value)}
+                    placeholder="Why do you want to visit this restaurant?"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none text-sm"
+                    rows={3}
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleSaveNote(wishlist.restaurantId)}
+                      disabled={updateNoteMutation.isLoading}
+                      className="px-3 py-1.5 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+                    >
+                      Save
+                    </button>
+                    <button
+                      onClick={handleCancelEdit}
+                      className="px-3 py-1.5 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 text-sm font-medium"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : wishlist.note ? (
+                <div className="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                  <p className="text-sm text-amber-800">
+                    <span className="font-medium">Note:</span> {wishlist.note}
+                  </p>
+                </div>
+              ) : (
+                <div className="mb-4">
+                  <p className="text-sm text-gray-500 italic">No note added</p>
+                </div>
+              )}
+
+              {/* Booking Window Hint */}
+              {wishlist.restaurant.bookingWindowDays && (
+                <div className="mb-4 p-2 bg-blue-50 border border-blue-200 rounded text-xs text-blue-800">
+                  <span className="font-medium">Booking tip:</span> Opens {wishlist.restaurant.bookingWindowDays} days in advance
+                </div>
+              )}
+
+              {/* Actions */}
+              <div className="flex gap-2 pt-4 border-t">
+                <button
+                  onClick={() => handleStartEditNote(wishlist)}
+                  className="flex-1 flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+                >
+                  <Edit3 className="h-4 w-4" />
+                  {wishlist.note ? 'Edit Note' : 'Add Note'}
+                </button>
+                <button
+                  onClick={() => removeFromWishlistMutation.mutate(wishlist.restaurantId)}
+                  disabled={removeFromWishlistMutation.isLoading}
+                  className="flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-red-600 bg-red-50 rounded-md hover:bg-red-100 transition-colors disabled:opacity-50"
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Remove
+                </button>
+              </div>
+
+              <div className="mt-2 text-xs text-gray-500">
+                Added {new Date(wishlist.createdAt).toLocaleDateString()}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WishlistPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -9,6 +9,9 @@ import type {
   FilterOptions,
   Restaurant,
   UserVisit,
+  Wishlist,
+  WishlistResponse,
+  WishlistCheckResponse,
 } from '../types';
 
 const API_BASE_URL = (import.meta as any).env.VITE_API_URL || 'http://localhost:3001/api';
@@ -143,6 +146,23 @@ export const scraperAPI = {
       output: string;
       stderr?: string;
     }>('/scraper/seed-production', { clearExisting }),
+};
+
+export const wishlistAPI = {
+  getWishlist: (page = 1, limit = 20) =>
+    api.get<WishlistResponse>('/wishlist', { params: { page, limit } }),
+
+  addToWishlist: (data: { restaurantId: string; note?: string }) =>
+    api.post<{ message: string; wishlist: Wishlist }>('/wishlist', data),
+
+  updateWishlistNote: (restaurantId: string, note: string) =>
+    api.patch<{ message: string; wishlist: Wishlist }>(`/wishlist/${restaurantId}`, { note }),
+
+  removeFromWishlist: (restaurantId: string) =>
+    api.delete<{ message: string }>(`/wishlist/${restaurantId}`),
+
+  checkWishlist: (restaurantId: string) =>
+    api.get<WishlistCheckResponse>(`/wishlist/check/${restaurantId}`),
 };
 
 export default api;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -22,6 +22,7 @@ export interface Restaurant {
   longitude?: number;
   description?: string;
   imageUrl?: string;
+  bookingWindowDays?: number;
   createdAt: string;
   updatedAt: string;
   visits?: Array<{
@@ -32,6 +33,9 @@ export interface Restaurant {
       username: string;
     };
   }>;
+  socialIndicator?: {
+    friendsVisitedCount: number;
+  };
 }
 
 export interface UserVisit {
@@ -99,4 +103,23 @@ export interface FilterOptions {
   countries: string[];
   cities: Array<{ city: string; country: string }>;
   cuisineTypes: string[];
+}
+
+export interface Wishlist {
+  id: string;
+  userId: string;
+  restaurantId: string;
+  note?: string;
+  createdAt: string;
+  restaurant: Restaurant;
+}
+
+export interface WishlistResponse {
+  wishlists: Wishlist[];
+  pagination: Pagination;
+}
+
+export interface WishlistCheckResponse {
+  inWishlist: boolean;
+  wishlist: Wishlist | null;
 }


### PR DESCRIPTION
## Summary

Implements the wishlist feature as described in issue #42. Users can now:
- Add/remove restaurants to/from wishlist
- Add optional notes explaining intent ("For Tokyo trip", etc.)
- View booking window hints when available
- See social indicators showing visitor counts
- Manage wishlist from dedicated page

## Changes

**Backend:**
- Added Wishlist model to Prisma schema
- Created wishlist API endpoints (POST, GET, PATCH, DELETE)
- Implemented social indicator logic
- Added bookingWindowDays to Restaurant model

**Frontend:**
- Created WishlistButton component
- Built WishlistPage for management
- Integrated into RestaurantDetailPage
- Added navigation menu link
- Updated types and API service

Fixes #42

🤖 Generated with [Claude Code](https://claude.ai/code)